### PR TITLE
fix: build on linux, add includes for std::find and std::strerror functions

### DIFF
--- a/src/odrive_cpp_sdk.cpp
+++ b/src/odrive_cpp_sdk.cpp
@@ -1,4 +1,6 @@
 #include "odrive_cpp_sdk/odrive_cpp_sdk.h"
+#include <algorithm>
+#include <cstring>
 
 using namespace odrive;
 
@@ -218,7 +220,7 @@ int CppSdk::initUSBHandlesBySNs() {
             } else if (libusb_kernel_driver_active(device_handle, 0) && ( (result = libusb_detach_kernel_driver(device_handle, 0)) != LIBUSB_SUCCESS )) { // detach kernel driver if necessary
                 std::cerr << "Could not call libusb_detach_kernel_driver: " << result << " - " << libusb_error_name(result) << std::endl;
             } else if ( (result = libusb_claim_interface(device_handle, 0)) !=  LIBUSB_SUCCESS ) {
-              std::cerr << "Could not call libusb_claim_interface: " << result << " - " << libusb_error_name(result) << ": " << strerror(errno) << std::endl;
+              std::cerr << "Could not call libusb_claim_interface: " << result << " - " << libusb_error_name(result) << ": " << std::strerror(errno) << std::endl;
               libusb_close(device_handle);
             } else {
                 bool attached_to_handle = false;
@@ -274,7 +276,7 @@ int CppSdk::odriveEndpointRequest(libusb_device_handle* handle, int endpoint_id,
 
     int result = libusb_bulk_transfer(handle, ODRIVE_SDK_WRITING_ENDPOINT, packet.data(), packet.size(), &sent_bytes, 0);
     if (result != LIBUSB_SUCCESS) {
-        std::cerr << "Could not call libusb_bulk_transfer for writing: " << result << " - " << libusb_error_name(result) << strerror(errno) << std::endl;
+        std::cerr << "Could not call libusb_bulk_transfer for writing: " << result << " - " << libusb_error_name(result) << std::strerror(errno) << std::endl;
         return result;
     } else if (packet.size() != sent_bytes) {
         std::cerr << "Could not call libusb_bulk_transfer: only wrote " << std::to_string(sent_bytes) << " of " << std::to_string(packet.size()) << " bytes (wanted to send `" << packet.data() << "`)" << std::endl;
@@ -284,7 +286,7 @@ int CppSdk::odriveEndpointRequest(libusb_device_handle* handle, int endpoint_id,
       // Immediatly wait for response from Odrive and check if ack (if we asked for one)
       result = libusb_bulk_transfer(handle, ODRIVE_SDK_READING_ENDPOINT, receive_bytes, ODRIVE_SDK_MAX_BYTES_TO_RECEIVE, &received_bytes, ODRIVE_SDK_TIMEOUT);
       if (result != LIBUSB_SUCCESS) {
-          std::cerr << "Could not call libusb_bulk_transfer for reading: " << result << " - " << libusb_error_name(result) << strerror(errno) << std::endl;
+          std::cerr << "Could not call libusb_bulk_transfer for reading: " << result << " - " << libusb_error_name(result) << std::strerror(errno) << std::endl;
           return result;
       }
 


### PR DESCRIPTION
I tried to build on Ubuntu 20.04 and faced with compile error.

```
odrive_cpp_sdk$ cmake -G Ninja -B build
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/viy/workspace/motor/odrive_cpp_sdk/build/devel
-- Using CMAKE_PREFIX_PATH: /opt/ros/noetic
-- This workspace overlays: /opt/ros/noetic
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.10", minimum required is "3") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python3
-- Using Debian Python package layout
-- Found PY_em: /usr/lib/python3/dist-packages/em.py  
-- Using empy: /usr/lib/python3/dist-packages/em.py
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/viy/workspace/motor/odrive_cpp_sdk/build/test_results
-- Forcing gtest/gmock from source, though one was otherwise available.
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python3 (found version "3.8.10") 
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests3
-- catkin 0.8.10
-- BUILD_SHARED_LIBS is on
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for one of the modules 'libusb-1.0'
-- Configuring done
-- Generating done
-- Build files have been written to: /home/viy/workspace/motor/odrive_cpp_sdk/build

odrive_cpp_sdk$ cmake --build build
[1/2] Building CXX object CMakeFiles/odrive_cpp_sdk.dir/src/odrive_cpp_sdk.cpp.o
FAILED: CMakeFiles/odrive_cpp_sdk.dir/src/odrive_cpp_sdk.cpp.o 
/usr/bin/c++  -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"odrive_cpp_sdk\" -Dodrive_cpp_sdk_EXPORTS -I../include -I/opt/ros/noetic/include -I/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -isystem /usr/include/libusb-1.0 -fPIC   -std=c++11 -MD -MT CMakeFiles/odrive_cpp_sdk.dir/src/odrive_cpp_sdk.cpp.o -MF CMakeFiles/odrive_cpp_sdk.dir/src/odrive_cpp_sdk.cpp.o.d -o CMakeFiles/odrive_cpp_sdk.dir/src/odrive_cpp_sdk.cpp.o -c ../src/odrive_cpp_sdk.cpp
../src/odrive_cpp_sdk.cpp: In member function ‘int odrive::CppSdk::init()’:
../src/odrive_cpp_sdk.cpp:102:173: error: no matching function for call to ‘find(std::string*&, std::string*, std::string&)’
  102 |         long sn_index = std::distance(odrive_serial_numbers_, std::find(odrive_serial_numbers_, odrive_serial_numbers_ + num_odrives_, motor_to_odrive_serial_number_map_[i]));
      |                                                                                                                                                                             ^
In file included from /usr/include/c++/9/bits/locale_facets.h:48,
                 from /usr/include/c++/9/bits/basic_ios.h:37,
                 from /usr/include/c++/9/ios:44,
                 from /usr/include/c++/9/ostream:38,
                 from /usr/include/c++/9/iostream:39,
                 from ../include/odrive_cpp_sdk/odrive_cpp_sdk.h:5,
                 from ../src/odrive_cpp_sdk.cpp:1:
/usr/include/c++/9/bits/streambuf_iterator.h:373:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT> >::__type std::find(std::istreambuf_iterator<_CharT>, std::istreambuf_iterator<_CharT>, const _CharT2&)’
  373 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/9/bits/streambuf_iterator.h:373:5: note:   template argument deduction/substitution failed:
../src/odrive_cpp_sdk.cpp:102:173: note:   mismatched types ‘std::istreambuf_iterator<_CharT>’ and ‘std::string*’ {aka ‘std::__cxx11::basic_string<char>*’}
  102 |         long sn_index = std::distance(odrive_serial_numbers_, std::find(odrive_serial_numbers_, odrive_serial_numbers_ + num_odrives_, motor_to_odrive_serial_number_map_[i]));
      |                                                                                                                                                                             ^
../src/odrive_cpp_sdk.cpp: In member function ‘int odrive::CppSdk::initUSBHandlesBySNs()’:
../src/odrive_cpp_sdk.cpp:221:129: error: ‘strerror’ was not declared in this scope; did you mean ‘perror’?
  221 |               std::cerr << "Could not call libusb_claim_interface: " << result << " - " << libusb_error_name(result) << ": " << strerror(errno) << std::endl;
      |                                                                                                                                 ^~~~~~~~
      |                                                                                                                                 perror
../src/odrive_cpp_sdk.cpp: In member function ‘int odrive::CppSdk::odriveEndpointRequest(libusb_device_handle*, int, commBuffer&, int&, commBuffer, int, int)’:
../src/odrive_cpp_sdk.cpp:277:125: error: ‘strerror’ was not declared in this scope; did you mean ‘perror’?
  277 |         std::cerr << "Could not call libusb_bulk_transfer for writing: " << result << " - " << libusb_error_name(result) << strerror(errno) << std::endl;
      |                                                                                                                             ^~~~~~~~
      |                                                                                                                             perror
../src/odrive_cpp_sdk.cpp:287:127: error: ‘strerror’ was not declared in this scope; did you mean ‘perror’?
  287 |           std::cerr << "Could not call libusb_bulk_transfer for reading: " << result << " - " << libusb_error_name(result) << strerror(errno) << std::endl;
      |                                                                                                                               ^~~~~~~~
      |                                                                                                                               perror
ninja: build stopped: subcommand failed.
```